### PR TITLE
Move CodeChecker analyze to test phase

### DIFF
--- a/codechecker/codechecker_script.py
+++ b/codechecker/codechecker_script.py
@@ -115,7 +115,9 @@ def input_data():
     logging.debug("      STORE_NAME     : %s", str(STORE_NAME))
     logging.debug("      STORE_TAG      : %s", str(STORE_TAG))
     logging.debug("")
-    # logging.debug("PATH=%s", execute("echo $PATH"))
+    logging.debug("PATH=%s", execute("echo $PATH"))
+    logging.debug("PWD=%s", execute("pwd"))
+    logging.debug("Tree:\n%s", execute("tree -aACF"))
 
 
 def execute(cmd, env=None, codes=None):
@@ -335,6 +337,9 @@ def main():
         if EXECUTION_MODE == "Run":
             run()
         elif EXECUTION_MODE == "Test":
+            test()
+        elif EXECUTION_MODE == "Full":
+            run()
             test()
         else:
             fail("Wrong codechecker script mode: %s" % EXECUTION_MODE)

--- a/codechecker/compile_commands.bzl
+++ b/codechecker/compile_commands.bzl
@@ -221,16 +221,14 @@ def collect_headers(target, ctx):
         headers = [target[CcInfo].compilation_context.headers]
     else:
         headers = []
-    headers = depset(headers)
     for attr in _source_attr:
         if hasattr(ctx.rule.attr, attr):
             deps = getattr(ctx.rule.attr, attr)
-            headers = [headers]
             for dep in deps:
                 if SourceFilesInfo in dep:
                     src = dep[SourceFilesInfo].headers
                     headers.append(src)
-            headers = depset(transitive = headers)
+    headers = depset(transitive = headers)
     return headers
 
 def _accumulate_transitive_source_files(accumulated, deps):

--- a/codechecker/compile_commands_filter.py
+++ b/codechecker/compile_commands_filter.py
@@ -20,6 +20,10 @@ COMPILE_COMMANDS_FILTER = {
         r" -MF \S* ": " ",
         r" -MT \S* ": " ",
     },
+    # Substract .../bin/.../_virtual_includes/...
+    r".*\/_virtual_includes\/": {
+        r" \S*\/bin\/(\S*\/_virtual_includes\/)": r" \1",
+    },
 }
 
 


### PR DESCRIPTION
Currently CodeChecker analyze is called on build phase.
This is an attempt to move CodeChecker analyze command to test phase.
